### PR TITLE
Fix Some Sentencing in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 # docstr
 > A document string minor mode.
 
-This package provides a simple solution to insert document string into the code.
+This package provides a simple solution for the insertion of documentation strings into code.
 
 ## Usage
 
-You can enable this package to a specific major mode, like
+You can enable this package for a specific major mode:
 
 ```el
 ;; Enable `docstr' inside these major modes.
@@ -20,16 +20,13 @@ You can enable this package to a specific major mode, like
 (add-hook 'java-mode-hook (lambda () (docstr-mode 1)))
 ```
 
-If you just want to enable it inside a specific buffer just call `docstr-mode`
-as a command throught minibuffer.
+Or if you just want to enable it inside a specific buffer just call `docstr-mode` as a command through the minibuffer:
 
 ```
 M-x docstr-mode
 ```
 
-To enable this package through out all the buffers by default. Call global
-version of the minor mode; then just put the following code snippet to your
-configuration.
+You can also enable this package in all buffers via:
 
 ```el
 (global-docstr-mode 1)
@@ -37,7 +34,7 @@ configuration.
 
 ## Supported Langauges
 
-Here is a list of all languages that support by this package.
+Here is a list of all languages that are supported by this package:
 
 * ActionScript
 * C / C++ / C#
@@ -50,27 +47,23 @@ Here is a list of all languages that support by this package.
 * Scala / Swift
 * TypeScript
 
-You can customize `docstr-writers-alist` variable to add your own document
-string support for your favourite language. Just add a cons cell like `(mode-name . docstr-writer-name)`.
+You can customize the `docstr-writers-alist` variable to add your own documentation string support for your favourite language. Just add a cons cell like `(mode-name . docstr-writer-name)`.
 
-To create your own document string writer, you would need to create a function
-that takes in one argument. For instance,
+To create your own documentation string writer, you need to create a function that takes in one argument. For instance:
 
 ```el
 (defun my-docstr-writer (search-string)
-  ;; Insert document stirng here.
+  ;; Insert documentation string here.
   )
 ```
 
-Argument `search-string` will be populated by the triggeration associated list.
-See variable `docstr-trigger-alist` for more information. For instance,
-a `C#` trigger data is like this
+The argument `search-string` will then be populated by the appropriate trigger function in `docstr-trigger-alist`. See the variable `docstr-trigger-alist` for more information. For instance, a `C#` trigger could look like this:
 
 ```el
 ("/" . docstr-trigger-csharp)
 ```
 
-And the triggeration function will look like this
+And the trigger function could look like this:
 
 ```el
 (defun docstr-trigger-csharp (&rest _)
@@ -85,11 +78,7 @@ And the triggeration function will look like this
     (docstr--insert-doc-string (docstr--c-style-search-string 2))))
 ```
 
-The document string is triggered by certain conditions are met; and it will
-finally calls the function `docstr--insert-doc-string` for document string
-insertion. In this example, `(docstr--c-style-search-string 2)` is the
-`search-string` ready for document string writer to write a proper document
-string base on the `search-string` information. Then this is the result.
+In this example, docstring insertion is triggered only when certain conditions are met; the function `docstr--insert-doc-string` will be called last of all to insert the actual docstring content. `(docstr--c-style-search-string 2)` is the `search-string` passed on to the documentation string writer which writes a proper documentation string based on its information.
 
 <p align="center">
 <img src="./etc/csharp/csharp-vs-doc-demo.gif" width="450" height="172"/>
@@ -97,23 +86,20 @@ string base on the `search-string` information. Then this is the result.
 
 ## Before/After Insertion
 
-You can customize document before or after the document string insertion.
-There are total two hooks you can customize.
+You can customize documentation before or after the docstring insertion.
+
+There are two hooks you can customize:
 
 * `docstr-before-insert-hook`
 * `docstr-after-insert-hook`
 
-The usage of this is to customize the document string with set up. For instance,
-some programming languages would add `@desc` before an actual description. Do
-the following can implement this.
+The use case of this is to provide some kind of set up. For instance, some programming languages would add `@desc` before an actual description. The following would implement this:
 
 ```el
 (add-hook 'docstr-before-insert-hook (lambda (search-string) (insert "@desc ")))
 ```
 
-Of course, I would recommend you add it locally so it is language specific
-document style. Let's try apply to language `TypeScript` only within
-`typescript-mode`.
+Of course, I would recommend you add it locally so it is language specific. Let's try to apply only to `TypeScript` and only within `typescript-mode`:
 
 ```el
 (defun my-typescript-mode-hook ()
@@ -128,10 +114,9 @@ document style. Let's try apply to language `TypeScript` only within
 <img src="./etc/typescript/ts-doc-demo.gif" width="450" height="149"/>
 </p>
 
-## Advance Implementation
+## Advanced Implementation
 
-You are able to customize document string by running `before`/`after` hooks.
-The following are advance examples for document string in `C++`.
+You can also customize documentation strings by running `before`/`after` hooks. The following are advanced examples for documentation strings in `C++`:
 
 | Preprocessor                          | Enumerator                          |
 |:--------------------------------------|:------------------------------------|
@@ -141,47 +126,40 @@ The following are advance examples for document string in `C++`.
 |:--------------------------------------|:-------------------------------------|
 | <img src="./etc/c++/cpp-struct.gif"/> | <img src="./etc/c++/cpp-class.gif"/> |
 
-## Document String
+## Documentation Strings
 
-You are able to customize default document string by tweaking these variables.
+You can customize default documentation strings by tweaking these variables.
 
 ### Type Name
 
-* `docstr-format-type` - default to `"{ %s }"`
+* `docstr-format-type` - default: `"{ %s }"`
 
-The default is wrap around curly brackets. It only takes one `%s` for type name
-to plug in.
+The default is wrap around curly brackets. It only takes one `%s` for the type name.
 
-* `docstr-show-type-name` - default to `t`
+* `docstr-show-type-name` - default: `t`
 
-If you don't want the type name to be shown; then set `docstr-show-type-name`
-to `nil` will make the trick. For instance, if you don't want the type name
-to be shown in `java-mode`; do the following.
+If you don't want the type name to be shown; then setting `docstr-show-type-name` to `nil` will do the trick. For instance, if you don't want the type name to be shown in `java-mode` do the following.
 
 ```el
 (add-hook 'java-mode-hook (lambda () (setq-local docstr-show-type-name nil)))
 ```
 
-* `docstr-default-typename` - default to `typename`
+* `docstr-default-typename` - default: `typename`
 
-You can change this value if you don't like the default type name. This
-variable is generally use for programming languages that aren't strong type.
-Like `Python`, `JavaScript`, `PHP`, etc.
+You can change this value if you don't like the default type name. This variable is generally used for programming languages that aren't statically typed like `Python`, `JavaScript`, `PHP`, etc.
 
 ### Variable Name
 
-* `docstr-format-var` - default to `"%s :"`
+* `docstr-format-var` - default: `"%s :"`
 
-The default is having colon `:` at the back of the variable name. It only takes one
-`%s` for variable name to plug in.
+The default is having a colon `:` at the back of the variable name. It only takes one `%s` for the variable name.
 
 ### Parameter & Return
 
-* `docstr-format-param` - default to `@param #T##V##D#`
-* `docstr-format-return` - default to `@return #T##V##D#`
+* `docstr-format-param` - default: `@param #T##V##D#`
+* `docstr-format-return` - default: `@return #T##V##D#`
 
-You can customize these variables for different document style. See the
-following talbe for desciption of key `#T#`, `#V#` and `#D#`.
+You can customize these variables for different documentation styles. See the following table for the desciption of the keys `#T#`, `#V#` and `#D#`:
 
 | Key   | Description                  |
 |:------|:-----------------------------|
@@ -189,52 +167,41 @@ following talbe for desciption of key `#T#`, `#V#` and `#D#`.
 | `#V#` | Key represent variable name. |
 | `#D#` | Key represent description.   |
 
-*P.S. These variables are constant value.*
+*P.S. These variables are constant.*
 
-### Default descriptions
+### Default Descriptions
 
-Here is a list of default description strings that you are allow to customize.
-These strings are placeholder before you actually replace these strings with
-realy content description.
+Here is a list of default description strings that you can customize. These strings are placeholders to remind you to replace these strings with content descriptions.
 
 * `docstr-desc-summary` - default to `"[summary]"`.
 * `docstr-desc-param` - default to `"[description]"`.
 * `docstr-desc-return` - default to `"[description]"`.
 * `docstr-desc-typename` - default to `"[type]"`.
 
-## Configure Faces
+## Faces Configuration
 
-This package provides a way to customize the document string faces in a
-consistent way yet this is just an optional choice. To enable this
-feature, you can put the following code snippet into your configuration.
+This package provides a way to customize the document string faces in a consistent way, though this is an optional choice. To enable this feature, you can put the following code snippet into your configuration:
 
 ```el
 (docstr-faces-apply)
 ```
 
-There are three faces that you can customize for document string.
+There are three faces that you can customize for documentation strings:
 
 * `docstr-faces-tag-face` - Highlight the tag face; like `@param`, `@return`, etc.
 * `docstr-faces-type-face` - Highlight the type name face.
 * `docstr-faces-value-face` - Highlight the variable name face.
 
-## Multiline Docstring & Keys
+## Multiline Docstrings & Keys
 
-Make sure you have starting and ending comment before triggering document string
-insertion from this package. For instance, you will need `/*` and `*/` before
-hitting return. There are several packages that can help you achieve this.
-You can also enable variable `docstr-key-support` for the built-in support
-from this package.
+Make sure you have starting and ending comments before triggering documentation string insertion using this package. For instance, you will need `/*` and `*/` before hitting return. There are several packages that can help you achieve this. You can also enable variable `docstr-key-support` for the built-in support from this package.
 
 ```el
-;; This fixes auto paring for document string which fulfill conditions
-;; from the multiline document stirng triggeration.
+;; This fixes auto pairing for documentation strings which fulfill conditions
+;; from the multiline documentation string trigger.
 (setq docstr-key-support t)
 ```
 
 ## Contribution
 
-If you would like to contribute to this project, you may either
-clone and make pull requests to this repository. Or you can
-clone the project and establish your own branch of this tool.
-Any methods are welcome!
+If you would like to contribute to this project, you can either clone and make pull requests to this repository. Or you can clone the project and establish your own branch of this tool. All methods are welcome!


### PR DESCRIPTION
Hi! I really like the package :slightly_smiling_face: , this PR just fixes some sentencing in the README - I hope this is accurate and helpful and not too intrusive. Changes mostly boil down to:

* document string -> documentation string
* triggeration function -> trigger function

Thanks!