### PR TITLE
Python smartparens Fix

### DIFF
--- a/langs/docstr-python.el
+++ b/langs/docstr-python.el
@@ -150,10 +150,10 @@
              ;; TODO: For some reason, '(nth 4 (syntax-ppss))' doesn't work.
              docstr-mode
              (docstr-util-looking-back "\"\"\"" 3))
-    (if (looking-at-p "\"\"\"")
-        (delete-char 3)
-      (save-excursion (insert "\"\"\""))
-      (docstr--insert-doc-string (docstr-python--parse)))))
+    (when (looking-at-p "\"\"\"")
+      (delete-char 3))
+    (save-excursion (insert "\"\"\""))
+    (docstr--insert-doc-string (docstr-python--parse))))
 
 (provide 'docstr-python)
 ;;; docstr-python.el ends here


### PR DESCRIPTION
Hi :wave: I think this PR should fix https://github.com/jcs-elpa/docstr/issues/5 (at least the behaviour with python + smartparens).

What I think was happening was that if `docstr-trigger-python` detected the next three chars were `"""` it would remove them and not call `(docstr--insert-doc-string (docstr-python--parse))` by virtue of the if-then-else (I don't think behaviour is intended? - please correct me on this if it is).

This path was always hit if smartparens mode was enabled since it inserts the three chars `"""` after the point once it detects three `"""` in a row.

Let me know if this fixes the issue ~ thanks Laurence