### PR TITLE
Fix conflict with smartparens

### DIFF
--- a/langs/docstr-python.el
+++ b/langs/docstr-python.el
@@ -149,11 +149,9 @@
   (when (and (memq major-mode docstr-python-modes)
              ;; TODO: For some reason, '(nth 4 (syntax-ppss))' doesn't work.
              docstr-mode
-             (docstr-util-looking-back "\"\"\"" 3))
-    (if (looking-at-p "\"\"\"")
-        (delete-char 3)
-      (save-excursion (insert "\"\"\""))
-      (docstr--insert-doc-string (docstr-python--parse)))))
+             (docstr-util-looking-back "\"\"\"" 3)
+             (looking-at-p "\"\"\""))
+    (docstr--insert-doc-string (docstr-python--parse))))
 
 (provide 'docstr-python)
 ;;; docstr-python.el ends here


### PR DESCRIPTION
For #5 and #10.

I think function `docstr-trigger-python` has been triggered twice in a row due to the functionality from `python-mode`. By adding the check `(looking-at-p "\"\"\"")` in the front should resolve this issue. And there is no need to remove and add those  double quotes back.