### PR TITLE
split param-string by escaping brackets to allow for type containing brackets

### DIFF
--- a/docstr-util.el
+++ b/docstr-util.el
@@ -134,6 +134,40 @@ or `suffix'."
     (suffix (string-suffix-p regexp str ignore-case))
     (t (string-match-p regexp str))))
 
+
+(defun docstr--split-string-escape-brackets (string separator)
+  "This code splits a STRING into multiple parts, based on a given SEPARATOR.
+It also accounts for inner brackets, such that strings within the same brackets
+will be considered as one string.
+
+Example usage:
+
+(split-string-by-separator \"This is [a test] string\" \" \")
+
+=> (\"This\" \"is\" \"[a test]\" \"string\")"
+  (let ((str-list '())
+        (start 0)
+        (end 0)
+        (in-brackets 0)
+        )
+    (dotimes (i (length string))
+      (let ((char (aref string i)))
+        (cond
+         ((equal (char-to-string char) separator)
+          (unless (> in-brackets 0)
+            (setq end i)
+            (push (substring string start end) str-list)
+            (setq start (+ i 1))))
+         ((equal char ?\[)
+          (setq in-brackets (+ in-brackets 1))
+          )
+         ((equal char ?\])
+          (setq in-brackets (- in-brackets 1))
+          ))))
+    (push (substring string start) str-list)
+    (nreverse str-list)))
+
+
 ;;
 ;; (@* "Insertion" )
 ;;

--- a/docstr-writers.el
+++ b/docstr-writers.el
@@ -31,6 +31,7 @@
 
 (declare-function docstr-form-param "ext:docstr.el")
 (declare-function docstr-form-return "ext:docstr.el")
+(declare-function docstr--split-string-escape-brackets "docstr-util")
 
 (defvar docstr-default-typename)
 (defvar docstr-desc-param)
@@ -185,7 +186,7 @@ the last word only."
           (ignore-errors (docstr-writers--analyze-param-string search-string)))
 
     (when (stringp param-string)
-      (setq param-lst (split-string param-string ",")))
+      (setq param-lst (docstr--split-string-escape-brackets param-string ",")))
     (when (docstr-writers--param-empty-p param-lst)
       (setq param-lst '()))
 


### PR DESCRIPTION
Types in Python might contain brackets and commas resulting in errors when parsing the parameters of the function. 

Example
```python
def foo(bar: Dict[str, Dict[str, str]]) -> Dict[str, Dict[str, str]]:
    pass
``` 
Results in 
<img width="650" alt="image" src="https://user-images.githubusercontent.com/3234544/233854595-7601ec18-d121-4d31-b1c9-4080764a54e3.png">

The PR creates a new function `docstr--split-string-escape-brackets` that split string while escaping the bracket to capture the full type:
<img width="589" alt="image" src="https://user-images.githubusercontent.com/3234544/233854665-fd129025-02da-4af6-a935-992638b84ed1.png">


